### PR TITLE
option handling; more flexible CSS; README.md details

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ Set one or more options for the timeselector.
 	
 **Code example:**
 	
-	$('[name="time"]').timeselector('option', {hours12: false});
+	$('[name="time"]').timeselector('option', {"hours12": false});
+
+*Note the double quotes around "hours12" which are not necessary for timeselector but are obligatory for correct [JSON](http://en.wikipedia.org/wiki/JSON) syntax which lies behind here*
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,28 @@ Decide between AM/PM / 12 hour (setting: true) or 24 hour (setting: false) clock
 Type: Number   
 The step size to adjust minutes when click the timeselector buttons or press the UP/DOWN KEY on the keyboard. You should set a starting value for your HTML input field (see Usage) if you want to achieve steps like "08:15 - 08:30 - 08:45" and so on.
 
+### Setting Options
+
+#### Via ```option``` Method
+
+See below. Note that this means changing the JavaScript section / file.
+
+
+#### Via an accompanying options ```input```
+
+If you prefer setting options *in situ* of the timeselector ```input``` tag in your HTML code you can apply a **hidden** HTML ```input``` element whose ```name``` is that of the timeselector input plus **-timeselector-opts**. The ```value``` of that additional input will be read out for timeselector options, e.g.
+
+	<input type="hidden" name="time-timeselector-opts" value='{ "hours12": false, "step": 15 }' />
+
+to set options for
+
+	<input type="text" name="time" value="08:15" />
+
+Note that an options ```input``` only applies if there are not already have been set options by the option **method**, i.e. you **cannot overwrite** settings in the JavaScript section / file by an options ```input``` (this is based on a model considering JavaScript  parts as "system level" and HTML as "content level").
+
+
+
+
 ## Methods
 **option( options )**  
 Returns: jQuery   

--- a/README.md
+++ b/README.md
@@ -2,15 +2,106 @@
 
 A simple jQuery plugin for time selection in form.
 
-**Version with ```jQuery``` as namespace descriptor ("function name") instead of its alias / shortcut ```$```**
-  * *Original version: https://github.com/nicolaszhao/timeselector*
-  * *This version: 2014-05-08 hh.lohmann@yahoo.de*
+**Current version:** [1.0.0](https://github.com/nicolaszhao/timeselector/archive/v1.0.0.tar.gz)
+
+## Usage
+Include jQuery and the plugin on your page. Then select a input element and call the timeselector method on DOM ready.
+
+	<script src="jquery.js"></script>
+	<script src="jquery.timeselector.js"></script>
+	<script>
+		$(function() {
+			$('[name="time"]').timeselector();
+		});
+	</script>
+	<input type="text" name="time" />
+
+If you want an initial "starting time" (what would make sense with the **step** option for minutes, see below) you should set this as the ```input```'s value, e.g.:
+
+	<input type="text" name="time" value="08:15" />
+	
+
+## Restrictions
+
+Due to implementation details you currently cannot have more than one timeselector on the same page (maybe you can if your browser applies some non-standard intelligence) since the checking logic for ```_checkExternalClick``` in ```src/jquery.timeselector.js``` depends on an element id that can [per definition](http://www.w3.org/TR/html401/struct/global.html#h-7.5.2) not exist more than one time in the same document. 
 
 
-## What's wrong with "$"?
+## Options
+**hours12** (default: true)   
+Type: Boolean   
+Decide between AM/PM / 12 hour (setting: true) or 24 hour (setting: false) clock.
 
-*Once upon a time, long before anyone could think of Javascript or even jQuery, [there were lots of higher (and lower) programming languages using "$" as a prefix for variables and some other stuff](http://en.wikipedia.org/wiki/Dollar_sign#Programming_languages). Then, in the beginning of the year 2005, there came [Prototype.js](http://en.wikipedia.org/wiki/Prototype.js), using "$" as a short form for some curious mixture of DOM and Javascript syntax, which was so impressing to some folks that they invented a whole new kingdom which they named "jQuery", and it took not long time that large parts of the world nowaddays grow up in the stern belief that jQuery is the current version of Javascript (if someone remembered "Javascript" at all) and that "$" is the basic building block of any computer that mankind ever had invented and ever will invent ...*
+***
 
-OK, let's get feet back onto the ground: you will run into some trouble if you implement jQuery or other code with "$" as a function name mixed with some other languages / [libraries](http://learn.jquery.com/using-jquery-core/avoid-conflicts-other-libraries/) or especially in a PHP based framework. The very easy solution is to use jQuery's actual function name which is, yes, "jQuery".
+**step** (default: 1)   
+Type: Number   
+The step size to adjust minutes when click the timeselector buttons or press the UP/DOWN KEY on the keyboard. You should set a starting value for your HTML input field (see Usage) if you want to achieve steps like "08:15 - 08:30 - 08:45" and so on.
+
+### Setting Options
+
+#### Via ```option``` Method
+
+See below. Note that this means changing the JavaScript section / file.
 
 
+#### Via an accompanying options ```input```
+
+If you prefer setting options *in situ* of the timeselector ```input``` tag in your HTML code you can apply a **hidden** HTML ```input``` element whose ```name``` is that of the timeselector input plus **-timeselector-opts**. The ```value``` of that additional input will be read out for timeselector options, e.g.
+
+	<input type="hidden" name="time-timeselector-opts" value='{ "hours12": false, "step": 15 }' />
+
+to set options for
+
+	<input type="text" name="time" value="08:15" />
+
+Note that an options ```input``` only applies if there are not already have been set options by the option **method**, i.e. you **cannot overwrite** settings in the JavaScript section / file by an options ```input``` (this is based on a model considering JavaScript  parts as "system level" and HTML as "content level").
+
+
+
+
+## Methods
+**option( options )**  
+Returns: jQuery   
+Set one or more options for the timeselector.
+	
+* **options**   
+	Type: Object   
+	A map of option-value pairs to set.
+	
+**Code example:**
+	
+	$('[name="time"]').timeselector('option', {"hours12": false});
+
+*Note the double quotes around "hours12" which are not necessary for timeselector but are obligatory for correct [JSON](http://en.wikipedia.org/wiki/JSON) syntax which lies behind here*
+
+***
+
+**refresh()**   
+Returns: jQuery   
+When the input value is set manually, need to call this method to manually update the timeselector and input value if the value is valid.
+
+**Code example:**
+	
+	$('[name="time"]').val('13:00').timeselector('refresh'); // input value will update to '01:00 PM'
+
+## Keyboard interaction
+* **UP**: Increment the minute by one step.
+* **DOWN**: Decrement the minute by one step.
+* **PAGE UP**: Increment one hour.
+* **PAGE DOWN**: Decrement one hour.
+* **ESCAPE**: Close the timeselector without selection.
+	
+## Theming
+If timeselector specific styling is needed, the following CSS class names can be used:
+* `timeselector`: The outer container of the timeselector.
+	* `timeselector-item`: The outer container of the hour or the minute section. The hour section will additionally have a `timeselector-hour` class and the minute section will additionally have a `timeselector-minute` class. 
+		* `timeselector-button`: The button controls used to increment and decrement the time's value. The up button will additionally have a `timeselector-up` class and the down button will additionally have a `timeselector-down` class.
+		* `timeselector-value`: The element to display the time's value.
+	* `timeselector-separator`: The separator of time.
+
+## Dependencies
+### Required
+[jQuery, tested with 1.10.2](http://jquery.com)
+
+## License
+Copyright (c) 2014 Nicolas Zhao; Licensed MIT

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ If you want an initial "starting time" (what would make sense with the **step** 
 
 	<input type="text" name="time" value="08:15" />
 	
+
+## Restrictions
+
+Due to implementation details you currently cannot have more than one timeselector on the same page (maybe you can if your browser applies some non-standard intelligence) since the checking logic for ```_checkExternalClick``` in ```src/jquery.timeselector.js``` depends on an element id that can [per definition](http://www.w3.org/TR/html401/struct/global.html#h-7.5.2) not exist more than one time in the same document. 
+
+
 ## Options
 **hours12** (default: true)   
 Type: Boolean   

--- a/README.md
+++ b/README.md
@@ -15,17 +15,21 @@ Include jQuery and the plugin on your page. Then select a input element and call
 		});
 	</script>
 	<input type="text" name="time" />
+
+If you want an initial "starting time" (what would make sense with the **step** option for minutes, see below) you should set this as the ```input```'s value, e.g.:
+
+	<input type="text" name="time" value="08:15" />
 	
 ## Options
 **hours12** (default: true)   
 Type: Boolean   
-Define whether or not to show AM/PM with selected time.
+Decide between AM/PM / 12 hour (setting: true) or 24 hour (setting: false) clock.
 
 ***
 
 **step** (default: 1)   
 Type: Number   
-The step size to adjust minutes when click the timeselector buttons or press the UP/DOWN KEY on the keyboard.
+The step size to adjust minutes when click the timeselector buttons or press the UP/DOWN KEY on the keyboard. You should set a starting value for your HTML input field (see Usage) if you want to achieve steps like "08:15 - 08:30 - 08:45" and so on.
 
 ## Methods
 **option( options )**  

--- a/README.md
+++ b/README.md
@@ -2,106 +2,15 @@
 
 A simple jQuery plugin for time selection in form.
 
-**Current version:** [1.0.0](https://github.com/nicolaszhao/timeselector/archive/v1.0.0.tar.gz)
-
-## Usage
-Include jQuery and the plugin on your page. Then select a input element and call the timeselector method on DOM ready.
-
-	<script src="jquery.js"></script>
-	<script src="jquery.timeselector.js"></script>
-	<script>
-		$(function() {
-			$('[name="time"]').timeselector();
-		});
-	</script>
-	<input type="text" name="time" />
-
-If you want an initial "starting time" (what would make sense with the **step** option for minutes, see below) you should set this as the ```input```'s value, e.g.:
-
-	<input type="text" name="time" value="08:15" />
-	
-
-## Restrictions
-
-Due to implementation details you currently cannot have more than one timeselector on the same page (maybe you can if your browser applies some non-standard intelligence) since the checking logic for ```_checkExternalClick``` in ```src/jquery.timeselector.js``` depends on an element id that can [per definition](http://www.w3.org/TR/html401/struct/global.html#h-7.5.2) not exist more than one time in the same document. 
+**Version with ```jQuery``` as namespace descriptor ("function name") instead of its alias / shortcut ```$```**
+  * *Original version: https://github.com/nicolaszhao/timeselector*
+  * *This version: 2014-05-08 hh.lohmann@yahoo.de*
 
 
-## Options
-**hours12** (default: true)   
-Type: Boolean   
-Decide between AM/PM / 12 hour (setting: true) or 24 hour (setting: false) clock.
+## What's wrong with "$"?
 
-***
+*Once upon a time, long before anyone could think of Javascript or even jQuery, [there were lots of higher (and lower) programming languages using "$" as a prefix for variables and some other stuff](http://en.wikipedia.org/wiki/Dollar_sign#Programming_languages). Then, in the beginning of the year 2005, there came [Prototype.js](http://en.wikipedia.org/wiki/Prototype.js), using "$" as a short form for some curious mixture of DOM and Javascript syntax, which was so impressing to some folks that they invented a whole new kingdom which they named "jQuery", and it took not long time that large parts of the world nowaddays grow up in the stern belief that jQuery is the current version of Javascript (if someone remembered "Javascript" at all) and that "$" is the basic building block of any computer that mankind ever had invented and ever will invent ...*
 
-**step** (default: 1)   
-Type: Number   
-The step size to adjust minutes when click the timeselector buttons or press the UP/DOWN KEY on the keyboard. You should set a starting value for your HTML input field (see Usage) if you want to achieve steps like "08:15 - 08:30 - 08:45" and so on.
-
-### Setting Options
-
-#### Via ```option``` Method
-
-See below. Note that this means changing the JavaScript section / file.
+OK, let's get feet back onto the ground: you will run into some trouble if you implement jQuery or other code with "$" as a function name mixed with some other languages / [libraries](http://learn.jquery.com/using-jquery-core/avoid-conflicts-other-libraries/) or especially in a PHP based framework. The very easy solution is to use jQuery's actual function name which is, yes, "jQuery".
 
 
-#### Via an accompanying options ```input```
-
-If you prefer setting options *in situ* of the timeselector ```input``` tag in your HTML code you can apply a **hidden** HTML ```input``` element whose ```name``` is that of the timeselector input plus **-timeselector-opts**. The ```value``` of that additional input will be read out for timeselector options, e.g.
-
-	<input type="hidden" name="time-timeselector-opts" value='{ "hours12": false, "step": 15 }' />
-
-to set options for
-
-	<input type="text" name="time" value="08:15" />
-
-Note that an options ```input``` only applies if there are not already have been set options by the option **method**, i.e. you **cannot overwrite** settings in the JavaScript section / file by an options ```input``` (this is based on a model considering JavaScript  parts as "system level" and HTML as "content level").
-
-
-
-
-## Methods
-**option( options )**  
-Returns: jQuery   
-Set one or more options for the timeselector.
-	
-* **options**   
-	Type: Object   
-	A map of option-value pairs to set.
-	
-**Code example:**
-	
-	$('[name="time"]').timeselector('option', {"hours12": false});
-
-*Note the double quotes around "hours12" which are not necessary for timeselector but are obligatory for correct [JSON](http://en.wikipedia.org/wiki/JSON) syntax which lies behind here*
-
-***
-
-**refresh()**   
-Returns: jQuery   
-When the input value is set manually, need to call this method to manually update the timeselector and input value if the value is valid.
-
-**Code example:**
-	
-	$('[name="time"]').val('13:00').timeselector('refresh'); // input value will update to '01:00 PM'
-
-## Keyboard interaction
-* **UP**: Increment the minute by one step.
-* **DOWN**: Decrement the minute by one step.
-* **PAGE UP**: Increment one hour.
-* **PAGE DOWN**: Decrement one hour.
-* **ESCAPE**: Close the timeselector without selection.
-	
-## Theming
-If timeselector specific styling is needed, the following CSS class names can be used:
-* `timeselector`: The outer container of the timeselector.
-	* `timeselector-item`: The outer container of the hour or the minute section. The hour section will additionally have a `timeselector-hour` class and the minute section will additionally have a `timeselector-minute` class. 
-		* `timeselector-button`: The button controls used to increment and decrement the time's value. The up button will additionally have a `timeselector-up` class and the down button will additionally have a `timeselector-down` class.
-		* `timeselector-value`: The element to display the time's value.
-	* `timeselector-separator`: The separator of time.
-
-## Dependencies
-### Required
-[jQuery, tested with 1.10.2](http://jquery.com)
-
-## License
-Copyright (c) 2014 Nicolas Zhao; Licensed MIT

--- a/src/jquery.timeselector.js
+++ b/src/jquery.timeselector.js
@@ -358,12 +358,18 @@
 				var method = $.fn.timeselector.timer[options];
 				
 				if (typeof method === 'function' && options.charAt(0) !== '_') {
-					          options = $.extend( $.fn.timeselector.defaults, args, options);
-					          $.fn.timeselector.timer._attach(this, options);
-
+					options = $.extend( $.fn.timeselector.defaults, args, options);
+					$.fn.timeselector.timer._attach(this, options);
 				}
 			});
 		} else {
+		        this.each ( function () { 
+		        	var arrOptsInputs = document.getElementsByName ( this.name + '-timeselector-opts' ) ;
+		        	if ( arrOptsInputs.length == 1 ) {
+		          		options = $.extend( $.fn.timeselector.defaults, JSON.parse ( arrOptsInputs[0].value ), options);
+		          		$.fn.timeselector.timer._attach(this, options);
+		        	}
+		      	}) ;
 			options = $.extend({}, $.fn.timeselector.defaults, options);
 			this.each(function() {
 				$.fn.timeselector.timer._attach(this, options);

--- a/src/jquery.timeselector.js
+++ b/src/jquery.timeselector.js
@@ -346,7 +346,7 @@
 	};
 
 	$.fn.timeselector = function(options) {
-		var args = Array.prototype.slice.call(arguments, 1);
+		var args = arguments[1] ;
 		
 		if (!$.fn.timeselector.timer.initialized) {
 			$.fn.timeselector.timer._create();
@@ -358,7 +358,9 @@
 				var method = $.fn.timeselector.timer[options];
 				
 				if (typeof method === 'function' && options.charAt(0) !== '_') {
-					method.apply($.fn.timeselector.timer, [this].concat(args));
+					          options = $.extend( $.fn.timeselector.defaults, args, options);
+					          $.fn.timeselector.timer._attach(this, options);
+
 				}
 			});
 		} else {

--- a/src/theme/jquery.timeselector.css
+++ b/src/theme/jquery.timeselector.css
@@ -1,4 +1,4 @@
-.timeselector { padding: 2px; line-height: 100%; color: #333; border: solid 1px #aaa; border-radius: 6px; background: #c9c9c9; position: absolute; overflow: hidden; 
+div.timeselector { padding: 2px; line-height: 100%; color: #333; border: solid 1px #aaa; border-radius: 6px; background: #c9c9c9; position: absolute; overflow: hidden; 
 	-moz-user-select: none;
 	-webkit-user-select: none;
 	-ms-user-select: none;


### PR DESCRIPTION
## jquery.timeselector.js:
### FIX: option handling

-- What: Picking directly `arguments[i]` (no error if not exists), merging it with defaults, attaching defaults
-- Why: Setting options as documented (see https://github.com/nicolaszhao/timeselector#options) made timeselector not work at all, unfortunately without an javascript error or something else
-- Note: I fear I didn't fully understand the original code at that place ... beg your pardon if mine's is rather primitive, but it works ...
### additional way for options

++ What: Adding a check for an INPUT element with `name=*name of timeselector input*-timeselector-opts` whose (unchecked!) VALUE will be applied as options (hours12 / step)
++ Why: In, e.g., a CMS you may have no access to the JavaScript part where you could set timeselector options via jQuery parameter, but to the HTML part where you could place an INPUT to store options for timeselector
++ Note: Imagine a CMS where timeselector is more generally invoked by `class` instead of `name` which would more easy allow for multiple timeselector inputs (provided a solution for (nicolaszhao#2) where you then can define an individual option input _in situ_ of each timeselector input
## jquery.timeselector.css: binding styles to div for more flexibility

++ What: `timeselector {` => `div.timeselector {`
++ Why: These styles are meant exclusively for the div that houses the + / - for time selection, making the deep connection to that div explicit allows using independent / more general `timeselector` class(es) (defined somewhere else), esp. giving the corresponding `input` element the class "timeselector" without being forced to state explicitly `input.timeselector` (which would make no sense if you want to say very general "this input belongs somehow to a timeselector context, details open" - but not (as for div.timeselector) "this input should behave in a very, very special way")
++ Note: changing to `div.timeselector` is "cheaper" than changing to something like "timeselector-div" which would require to change also the JS code
## README.md
### some detail on options hours12 and step

-- What: adding some detail to Usage and Options for `step` and stating `hours12` clearer
-- Why: `step`: one might start with changing timeselector's by overseeing that setting a starting time in the HTML page does the job; `hours12`: "whether or not to show AM/PM" does not describe it exactly
### only one timeselector per page

++ What: Adding section "Restrictions" to make prominent that you can only have one timeselector per page
++ Why: Beside reporting the stated fact as an issue it should be kept in mind for implementing timeselector for the time being
### JSON standard compliance in example

++ What: changing example JSON `{hours12: false}` to `{"hours12": false}` to comply with [The JSON Lexical Grammar](http://www.ecma-international.org/ecma-262/5.1/#sec-15.12.1.1)
++ Why: Copying the example without double quotes around the JSONString keyword (here: "hours12") to general JavaScript contexts will produce errors, see also [jQuery.parseJSON()](http://api.jquery.com/jquery.parsejson/)
### Adding additional way for options

see (https://github.com/hh-lohmann/timeselector/commit/3a9dd782ce87df041ecfe916df18b22386c84801)
